### PR TITLE
クラス名出力の修正

### DIFF
--- a/Chap10/複数インターフェースの実装/複数インターフェースの実装/Program.cs
+++ b/Chap10/複数インターフェースの実装/複数インターフェースの実装/Program.cs
@@ -13,11 +13,11 @@ class C : A, B
 {
     public void MyMethodA()
     {
-        Console.WriteLine("in B:MyMethodA");
+        Console.WriteLine("in C:MyMethodA");
     }
     public void MyMethodB()
     {
-        Console.WriteLine("in B:MyMethodB");
+        Console.WriteLine("in C:MyMethodB");
     }
 }
 


### PR DESCRIPTION
```csharp
Console.WriteLine("in C:MyMethodA");
```
となるべきところ
```csharp
Console.WriteLine("in B:MyMethodA");
```

となっていたので修正しました。